### PR TITLE
Remove package from AndroidManifest file

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.giphy.giphy_flutter_sdk">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
My project configuration : 
- Flutter SDK 3.27.1
- distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
- Added **android.defaults.buildfeatures.buildconfig=true** in app/gradle.properties File. 

I am facing below issue and based on suggestion I did some changes. Please review it.

<img width="1425" alt="Screenshot 2025-01-30 at 4 53 54 PM" src="https://github.com/user-attachments/assets/f105da26-9d1d-45d2-a1bf-1346f546943e" />
