### PR TITLE
- release 1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.0.8
+
+### Native SDKs
+
+- Giphy Android SDK [v2.4.2](https://github.com/Giphy/giphy-android-sdk/releases/tag/v2.4.2)
+- Giphy iOS SDK [v2.3.1](https://github.com/Giphy/giphy-ios-sdk/releases/tag/2.3.1)
+
+### Bug Fixes
+- Address [Selecting Explicit Gifs and Stickers does not return on iOS](https://github.com/Giphy/giphy-flutter-sdk/issues/54)
+
 ## 1.0.7
 
 ### Native SDKs

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -96,7 +96,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'com.giphy.sdk:ui:2.4.1'
+        implementation 'com.giphy.sdk:ui:2.4.2'
     }
 
     buildFeatures {

--- a/lib/dto/giphy_rating.dart
+++ b/lib/dto/giphy_rating.dart
@@ -32,7 +32,7 @@ extension GiphyRatingExtension on GiphyRating {
   ///
   /// Returns the matching [GiphyRating] value.
   static GiphyRating fromStringValue(String value) {
-    switch (value) {
+    switch (value.toLowerCase().replaceAll('-', '')) {
       case 'r':
         return GiphyRating.r;
       case 'y':

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: giphy_flutter_sdk
 description: "A Flutter plugin for integrating Giphy SDK in Android/iOS application."
-version: 1.0.7
+version: 1.0.8
 homepage: https://github.com/Giphy/giphy-flutter-sdk
 
 environment:


### PR DESCRIPTION
- build(deps): bump Android SDK version from 2.4.1 to 2.4.2
- fix(iOS): Dialog media selection for pg-13 explicit content, Fixes #54