### PR TITLE
- release 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.1.2
+
+### Native SDKs
+
+- Giphy Android SDK [v2.5.1](https://github.com/Giphy/giphy-android-sdk/releases/tag/v2.5.1)
+- Giphy iOS SDK [v2.3.2](https://github.com/Giphy/giphy-ios-sdk/releases/tag/2.3.2)
+
+### Bug Fixes
+- Address [Android build fails: RecyclerView 1.4.0 requires compileSdk 35 but plugin defaults to 34](https://github.com/Giphy/giphy-flutter-sdk/issues/65)
+
 ## 1.1.1
 
 ### Native SDKs

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -14,4 +14,4 @@
 GiphyFlutterSDK.kotlinVersion=1.7.20
 GiphyFlutterSDK.minSdkVersion=23
 GiphyFlutterSDK.targetSdkVersion=31
-GiphyFlutterSDK.compileSdkVersion=34
+GiphyFlutterSDK.compileSdkVersion=36

--- a/example/android/app/proguard-rules.pro
+++ b/example/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+-dontwarn kotlinx.parcelize.Parcelize

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: giphy_flutter_sdk
 description: "A Flutter plugin for integrating Giphy SDK in Android/iOS application."
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/Giphy/giphy-flutter-sdk
 
 environment:


### PR DESCRIPTION
- fix(Android): Android build fails: RecyclerView 1.4.0 requires compileSdk 35 but plugin defaults to 34, fixes #65